### PR TITLE
feat: django mysql 연결, docker mysql, django app container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.10.11
+
+WORKDIR /aid_web
+
+COPY ./pyproject.toml ./poetry.lock ./
+
+RUN pip install poetry && poetry config virtualenvs.create false
+RUN poetry install

--- a/aid_web/aid_web/settings.py
+++ b/aid_web/aid_web/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
+import os
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -38,6 +39,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "rest_framework",  # Django RestFrameWork 사용
+    "testapp",
 ]
 
 MIDDLEWARE = [
@@ -76,8 +78,12 @@ WSGI_APPLICATION = "aid_web.wsgi.application"
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": BASE_DIR / "db.sqlite3",
+        "ENGINE": "django.db.backends.mysql",
+        "NAME": os.environ.get("mysql_db_name"),
+        "USER": os.environ.get("mysql_user"),
+        "PASSWORD": os.environ.get("mysql_password"),
+        "HOST": os.environ.get("mysql_host"),
+        "PORT": os.environ.get("mysql_port"),
     }
 }
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,54 @@
+# https://velog.io/@rlagurwns112/docker-compose%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-django-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-%EB%B0%B0%ED%8F%AC
+
+version: '3.8'
+
+services:
+  server:
+    container_name: DjangoApp
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: always
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ./aid_web:/aid_web
+    command: sh -c "cd /aid_web && python manage.py makemigrations && python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
+    ports:
+      - 8000:8000
+    environment:
+      TZ: "Asia/Seoul"
+    env_file:
+      - ./env/.server.env
+    networks:
+      - aid
+
+  db:
+    container_name: db
+    image: mysql
+    restart: always
+    volumes:
+      - data-vol:/var/lib/mysql
+    command: mysqld --character-set-server=utf8 --collation-server=utf8_general_ci  # 유니코드 설정
+    expose:
+      - 3306
+    ports:
+      - 3306:3306
+    env_file:
+      - ./env/.db.env
+    networks:
+      - aid
+    # mysql 서버가 열리는 데 시간이 걸리므로 healthcheck 후에 django container run (https://stackoverflow.com/questions/42567475/docker-compose-check-if-mysql-connection-is-ready)
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "db"]
+      timeout: 5s
+      retries: 1000
+
+networks:
+  aid:
+    driver: bridge
+
+volumes:
+  data-vol:
+    driver: local

--- a/docs/docker_setting.md
+++ b/docs/docker_setting.md
@@ -1,0 +1,36 @@
+# Develop Server
+
+## docker-compose.yaml
+- docker compose를 사용해, nginx 서버(미구현), Django, MySQL 서버 각각의 container를 deploy할 수 있도록 해주는 파일
+- docker container는 `aid` 이름의 network 사용
+- `server` : Django server
+  - Django는 `manage.py`를 실행시켜 동작, runserver 이전 makemigrations 및 migrate 수행.
+  - db server가 완전히 열린 후 django server가 열려야 하므로 health check를 통해 MySQL 서버가 정상적으로 동작할 때 django container deploy.
+  - 8000번 port 사용
+  - Django 내의 `settings.py` 에서 MySQL 서버에 접속하기 위한 환경 변수 파일은 `./env/.server.env` 사용
+- `db` : MySQL server
+  - mysql image 사용
+  - database 파일은 `/var/lib/mysql`에 mount
+  - MySQL container는 3306 port를 통해 접속 가능하도록 설정
+  - 환경 변수 파일은 `./env/.db.env`사용
+  - health checking을 위해 MySQL 서버에 ping. 실패 시 5초마다 재시도.
+  - DB 내 한글 사용을 위해 유니코드 설정(`mysqld --character-set-server=utf8 --collation-server=utf8_general_c`)
+- MySQL environment variable
+  - `MYSQL_USER` : MySQL에 접속할 사용자
+  - `MYSQL_ROOT_PASSWORD` : MySQL root user 비밀번호(필수로 지정해야 함.)
+  - `MYSQL_PASSWORD` : MYSQL_USER에 대한 비밀번호
+  - `MYSQL_HOST` : MySQL 서버 host name. container 이름에 맞게 `db`로 설정
+  - `MYSQL_DATABASE` : 생성할 데이터베이스 이름
+  ```
+  # .db.env
+
+  MYSQL_USER=****
+  MYSQL_ROOT_PASSWORD=****
+  MYSQL_PASSWORD=****
+  MYSQL_HOST=db
+  MYSQL_DATABASE=****
+  ```
+
+## Dockerfile
+Django용 이미지 생성을 위한 Dockerfile. poetry 설치 후, pyproject.toml 내의 패키지 설치
+Django 서버 이미지 생성을 위한 도커 파일

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 python = "^3.10"
 django = "^4.2.7"
 djangorestframework = "^3.14.0"
+mysqlclient = "^2.2.1"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
`settings.py`에 mysql 연결 추가 및 mysql, django 프로젝트 container 띄우는 docker-compose 작성

확인은 `docker compose up` 후 `127.0.0.1:8000`으로 접속

database 설정 적어놓은 server 및 db용 .env 파일 필요

------------------
* nginx는 띄우지 않아 80번 포트로는 아직 접속 안됩니다.
* 현재 dev branch DB에 수정사항 필요한 것으로 알고있는데(`null=True` 등) 수정 이후에 동작합니다.
* .env 파일은 notion에 기록
* 혹시 cannot connect to database server뜨면 `docker compose down -v`로 volume 삭제 후 다시 compose  

-----------------
~~closes: #1~~
related to: #4 
