### PR TITLE
Study api 추가

### DIFF
--- a/aid_web/config/settings/base.py
+++ b/aid_web/config/settings/base.py
@@ -36,7 +36,7 @@ ALLOWED_HOSTS = []
 
 INSTALLED_APPS = [
     "userapp.apps.UserappConfig",
-    # "studyapp.apps.StudyappConfig",
+    "studyapp.apps.StudyappConfig",
     # "projectapp.apps.ProjectappConfig",
     "django.contrib.admin",
     "django.contrib.auth",
@@ -126,7 +126,8 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = "UTC"
+# Datetime의 현재 시간을 한국 시간으로 설정.
+TIME_ZONE = "Asia/Seoul"
 
 USE_I18N = True
 

--- a/aid_web/config/urls.py
+++ b/aid_web/config/urls.py
@@ -22,7 +22,7 @@ from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, Spec
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("studyapp/", include("studyapp.urls")),
+    path("api/", include("studyapp.urls")),
     path("api/", include("userapp.urls")),
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     path("api/schema/swagger-ui/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),

--- a/aid_web/config/urls.py
+++ b/aid_web/config/urls.py
@@ -19,4 +19,8 @@ from django.urls import include, path
 
 # from testapp.views import hello_rest_api
 
-urlpatterns = [path("admin/", admin.site.urls), path("userapp/", include("userapp.urls"))]
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("userapp/", include("userapp.urls")),
+    path("studyapp/", include("studyapp.urls")),
+]

--- a/aid_web/studyapp/docs.py
+++ b/aid_web/studyapp/docs.py
@@ -1,0 +1,140 @@
+# flake8: noqa
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema, extend_schema_view
+
+from .serializer import StudySerializer, StudyUserSerializer
+
+study_extend_schema_view = extend_schema_view(
+    list=extend_schema(tags=["스터디 CRUD"], description="스터디 목록 확인.\n\n로그인하지 않은 사용자도 확인 가능.", responses=StudySerializer),
+    retrieve=extend_schema(
+        tags=["스터디 CRUD"],
+        description="스터디 상세정보 확인.",
+        responses=StudySerializer,
+        request=StudySerializer,
+        parameters=[
+            OpenApiParameter(
+                name="id", type=int, location=OpenApiParameter.PATH, description="확인할 스터디 id", required=True
+            )
+        ],
+    ),
+    create=extend_schema(
+        tags=["스터디 CRUD"],
+        description="스터디 생성.\n\n스터디 이름, 상태는 필수로 입력. 설명, 이미지 url, 스터디 링크는 선택적으로 입력 가능.  \n스터디 상태는 0-`Opened`, 1-`Closed`, 2-`Finished`를 의미.",
+        responses=StudySerializer,
+        request=StudySerializer,
+    ),
+    update=extend_schema(
+        tags=["스터디 CRUD"],
+        description="스터디 수정",
+        responses={
+            200: OpenApiResponse(response=StudySerializer, description="스터디 수정 성공"),
+            403: OpenApiResponse(description="스터디 수정 권한이 없음"),
+            404: OpenApiResponse(description="스터디가 존재하지 않음"),
+        },
+        request=StudySerializer,
+        parameters=[
+            OpenApiParameter(
+                name="id", type=int, location=OpenApiParameter.PATH, description="수정할 스터디 id", required=True
+            )
+        ],
+    ),
+    destroy=extend_schema(
+        tags=["스터디 CRUD"],
+        description="스터디 삭제",
+        responses={
+            204: OpenApiResponse(description="스터디 삭제 성공"),
+            403: OpenApiResponse(description="스터디 삭제 권한이 없음"),
+            404: OpenApiResponse(description="스터디가 존재하지 않음"),
+        },
+        parameters=[
+            OpenApiParameter(
+                name="id", type=int, location=OpenApiParameter.PATH, description="삭제할 스터디 id", required=True
+            )
+        ],
+    ),
+    quit=extend_schema(
+        tags=["스터디 나가기"],
+        description="스터디 나가기.\n\nAPI호출 대상이 되는 스터디에 현재 로그인 한 사용자가 있다면, 스터디를 나감. 스터디 leader라면 leader를 None으로 변경.",
+        request=None,
+        responses={
+            200: OpenApiResponse(response=StudySerializer, description="스터디 나가기 성공"),
+        },
+        parameters=[
+            OpenApiParameter(
+                name="id", type=int, location=OpenApiParameter.PATH, description="나갈 스터디 id", required=True
+            )
+        ],
+    ),
+    join=extend_schema(
+        tags=["스터디 참가, 승인"],
+        description="스터디 참가.\n\n현재 로그인 된 사용자 이름으로 스터디 참가 신청.",
+        request=None,
+        responses={
+            200: OpenApiResponse(response=StudySerializer, description="스터디 참가 성공"),
+            403: OpenApiResponse(description="이미 스터디에 참가함, 스터디가 Opened 상태가 아님."),
+        },
+        parameters=[
+            OpenApiParameter(
+                name="id", type=int, location=OpenApiParameter.PATH, description="참가할 스터디 id", required=True
+            )
+        ],
+    ),
+    approval=extend_schema(
+        tags=["스터디 참가, 승인"],
+        description="스터디 참가 승인을 위해 스터디 참가자 목록 확인.\n\n스터디에 참가중인 사용자와, 참가 신청한 사용자가 함께 표시되고, 승인되지 않은 사용자는 `is_approve`가 `false`로 표시.",
+        request=None,
+        responses=StudyUserSerializer,
+        parameters=[
+            OpenApiParameter(
+                name="id", type=int, location=OpenApiParameter.PATH, description="참가자 목록을 확인할 스터디 id", required=True
+            )
+        ],
+    ),
+    approval_with_id=extend_schema(
+        tags=["스터디 참가, 승인"],
+        description="스터디 참가 승인.\n\n스터디 leader나 admin만 가능.",
+        request=None,
+        responses={
+            200: OpenApiResponse(response=StudyUserSerializer, description="참가 승인 성공"),
+            404: OpenApiResponse(description="스터디 또는 참가자가 존재하지 않음"),
+        },
+        parameters=[
+            OpenApiParameter(
+                name="id", type=int, location=OpenApiParameter.PATH, description="참가자를 승인할 스터디 id", required=True
+            ),
+            OpenApiParameter(
+                name="user_id", type=int, location=OpenApiParameter.PATH, description="참가 승인할 사용자 id", required=True
+            ),
+        ],
+    ),
+    reject_with_id=extend_schema(
+        tags=["스터디 참가, 승인"],
+        description="참가자 삭제.\n\nleader가 자기 자신을 삭제하거나, admin이 leader를 삭제하는 것은 불가능. leader를 다른 사람에게 넘겨줘야 가능함.  \n로그인 된 사용자가 자기 자신을 스터디에서 삭제하려면 `quit` API를 사용.",
+        request=None,
+        responses={
+            200: OpenApiResponse(response=StudySerializer, description="참가자 삭제 성공"),
+            403: OpenApiResponse(description="스터디 leader를 삭제하려고 시도함."),
+        },
+        parameters=[
+            OpenApiParameter(
+                name="id", type=int, location=OpenApiParameter.PATH, description="참가자를 삭제할 스터디 id", required=True
+            ),
+            OpenApiParameter(
+                name="user_id", type=int, location=OpenApiParameter.PATH, description="삭제할 사용자 id", required=True
+            ),
+        ],
+    ),
+    set_leader_with_id=extend_schema(
+        tags=["스터디 리더 변경"],
+        description="스터디 리더 변경.",
+        request=None,
+        responses=StudySerializer,
+        parameters=[
+            OpenApiParameter(
+                name="id", type=int, location=OpenApiParameter.PATH, description="리더를 변경할 스터디 id", required=True
+            ),
+            OpenApiParameter(
+                name="user_id", type=int, location=OpenApiParameter.PATH, description="리더로 설정할 사용자 id", required=True
+            ),
+        ],
+    ),
+)

--- a/aid_web/studyapp/models.py
+++ b/aid_web/studyapp/models.py
@@ -1,15 +1,22 @@
 from django.db import models
-from django.db.models import Model
+from django.db.models import IntegerChoices, Model
 from userapp.models import User
 
 
 class Study(Model):
+    # https://www.b-list.org/weblog/2007/nov/02/handle-choices-right-way/
+    class StatusType(IntegerChoices):
+        OPENED = 0, "Opened"
+        CLOSED = 1, "Closed"
+        FINISHED = 2, "Finished"
+
     study_name = models.CharField(max_length=50, unique=True, blank=True)
     study_description = models.CharField(max_length=300, blank=True)
     study_link = models.CharField(max_length=500, null=True)
-    status = models.IntegerField(default=0)
+    status = models.IntegerField(choices=StatusType.choices, default=StatusType.OPENED)
     leader = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, related_name="leader")
     users = models.ManyToManyField(User)  # realted name
+    # users_waiting = models.ManyToManyField(User, blank=True, related_name="users_waiting")
     img_url = models.CharField(max_length=100)
     created_at = models.DateTimeField(auto_now=True)
 
@@ -18,3 +25,4 @@ class Study(Model):
 
     class Meta:
         db_table = "Study"
+        get_latest_by = ("status", "created_at")

--- a/aid_web/studyapp/models.py
+++ b/aid_web/studyapp/models.py
@@ -10,7 +10,7 @@ class Study(Model):
         CLOSED = 1, "Closed"
         FINISHED = 2, "Finished"
 
-    study_name = models.CharField(max_length=50, unique=True, blank=True)
+    study_name = models.CharField(max_length=50, unique=True)
     study_description = models.CharField(max_length=300, blank=True)
     study_link = models.CharField(max_length=500, null=True)
     status = models.IntegerField(choices=StatusType.choices, default=StatusType.OPENED)

--- a/aid_web/studyapp/models.py
+++ b/aid_web/studyapp/models.py
@@ -15,7 +15,7 @@ class Study(Model):
     study_link = models.CharField(max_length=500, null=True)
     status = models.IntegerField(choices=StatusType.choices, default=StatusType.OPENED)
     leader = models.ForeignKey(User, on_delete=models.SET_NULL, null=True, related_name="leader")
-    users = models.ManyToManyField(User)  # realted name
+    users = models.ManyToManyField(User, through="StudyUserRelation")  # realted name
     # users_waiting = models.ManyToManyField(User, blank=True, related_name="users_waiting")
     img_url = models.CharField(max_length=100)
     created_at = models.DateTimeField(auto_now=True)
@@ -26,3 +26,13 @@ class Study(Model):
     class Meta:
         db_table = "Study"
         get_latest_by = ("status", "created_at")
+
+
+class StudyUserRelation(models.Model):
+    # 스터디 참여 여부 및 확장성을 위한 중간 테이블 명시.
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    study = models.ForeignKey(to=Study, on_delete=models.CASCADE)
+    is_approve = models.BooleanField(default=False)
+
+    class Meta:
+        db_table = "study_user"

--- a/aid_web/studyapp/permissions.py
+++ b/aid_web/studyapp/permissions.py
@@ -3,7 +3,7 @@ from rest_framework import permissions
 
 class IsOwnerOfStudyOrAdmin(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
-        if request.method in permissions.SAFE_METHODS:
-            return True
+        # if request.method in permissions.SAFE_METHODS:
+        #     return True
 
-        return obj.leader == request.user or request.user.is_admin
+        return obj.leader == request.user or request.user.is_staff

--- a/aid_web/studyapp/permissions.py
+++ b/aid_web/studyapp/permissions.py
@@ -1,9 +1,9 @@
 from rest_framework import permissions
 
 
-class IsOwnerOfStudyOrReadOnly(permissions.BasePermission):
+class IsOwnerOfStudyOrAdmin(permissions.BasePermission):
     def has_object_permission(self, request, view, obj):
         if request.method in permissions.SAFE_METHODS:
             return True
 
-        return obj.leader == request.user
+        return obj.leader == request.user or request.user.is_admin

--- a/aid_web/studyapp/permissions.py
+++ b/aid_web/studyapp/permissions.py
@@ -1,0 +1,9 @@
+from rest_framework import permissions
+
+
+class IsOwnerOfStudyOrReadOnly(permissions.BasePermission):
+    def has_object_permission(self, request, view, obj):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        return obj.leader == request.user

--- a/aid_web/studyapp/serializer.py
+++ b/aid_web/studyapp/serializer.py
@@ -6,6 +6,8 @@ from userapp.models import User
 
 from .models import Study, StudyUserRelation
 
+# from .docs import study_extend_schema_serializer
+
 # https://www.django-rest-framework.org/api-guide/relations/
 
 # CRUD별로 다른 serializer를 써야할 때
@@ -19,6 +21,23 @@ class UserSerializer(serializers.ModelSerializer):
         fields = ("id", "nick_name", "email")
 
 
+@extend_schema_serializer(
+    many=True,
+    examples=[
+        OpenApiExample(
+            "스터디 내 사용자 정보",
+            summary="스터디 내 사용자 정보",
+            value={
+                "study_name": "study1",
+                "user_email": "testname@example.com",
+                "user_id": 1,
+                "is_approve": True,
+            },
+            request_only=False,
+            response_only=True,
+        )
+    ],
+)
 class StudyUserSerializer(serializers.Serializer):
     study_name = serializers.CharField(source="study.study_name")
     user_email = serializers.CharField(source="user.email")
@@ -34,8 +53,8 @@ class StudyUserSerializer(serializers.Serializer):
     examples=[
         OpenApiExample(
             "스터디 정보",
-            summary="스터디 정보 summary",
-            description="스터디 정보 description",
+            summary="스터디 정보",
+            description="스터디 정보 출력",
             value={
                 "id": 1,
                 "status_readable": "Opened",
@@ -55,8 +74,8 @@ class StudyUserSerializer(serializers.Serializer):
         ),
         OpenApiExample(
             "스터디 생성",
-            summary="스터디 생성 summary",
-            description="스터디 생성 description",
+            summary="스터디 생성",
+            description="스터디 생성 및 수정용 response body",
             value={
                 "study_name": "test study name",
                 "study_description": "test study description",

--- a/aid_web/studyapp/serializer.py
+++ b/aid_web/studyapp/serializer.py
@@ -1,0 +1,25 @@
+from rest_framework import serializers
+from userapp.models import User
+
+from .models import Study
+
+# https://www.django-rest-framework.org/api-guide/relations/
+
+# CRUD별로 다른 serializer를 써야할 때
+# https://velog.io/@haremeat/Django-%ED%95%98%EB%82%98%EC%9D%98-APIView%EC%97%90%EC%84%9C-Serializerclass%EA%B0%80-%EB%8B%A4%EB%A5%BC-%EB%95%8C
+# https://github.com/encode/django-rest-framework/issues/1563
+
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ("id", "nick_name", "email")
+
+
+class StudySerializer(serializers.ModelSerializer):
+    leader = UserSerializer(many=False, read_only=True)
+    users = UserSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = Study
+        fields = "__all__"

--- a/aid_web/studyapp/serializer.py
+++ b/aid_web/studyapp/serializer.py
@@ -1,5 +1,6 @@
 from typing import Any
 
+from drf_spectacular.utils import OpenApiExample, extend_schema_serializer
 from rest_framework import serializers
 from userapp.models import User
 
@@ -29,6 +30,59 @@ class StudyUserSerializer(serializers.Serializer):
         fields = ("study_name", "user_email", "user_id", "is_approve")
 
 
+@extend_schema_serializer(
+    examples=[
+        OpenApiExample(
+            "스터디 정보",
+            summary="스터디 정보 summary",
+            description="스터디 정보 description",
+            value={
+                "id": 1,
+                "status_readable": "Opened",
+                "leader": {"id": 1, "nick_name": "testname1", "email": "testname1@example.com"},
+                "users": [
+                    {"study_name": "study1", "user_email": "testname1@example.com", "user_id": 1, "is_approve": True}
+                ],
+                "study_name": "study1",
+                "study_description": "testdescription1",
+                "study_link": None,
+                "status": 0,
+                "img_url": "test",
+                "created_at": "2024-01-01T00:00:00.000000Z",
+            },
+            request_only=False,
+            response_only=True,
+        ),
+        OpenApiExample(
+            "스터디 생성",
+            summary="스터디 생성 summary",
+            description="스터디 생성 description",
+            value={
+                "study_name": "test study name",
+                "study_description": "test study description",
+                "status": 0,
+                "study_url": "http://test.study.url/",
+                "img_url": "testimg.jpg",
+            },
+            request_only=True,
+            response_only=False,
+        ),
+        OpenApiExample(
+            "스터디 수정",
+            summary="스터디 수정 summary",
+            description="스터디 수정 description",
+            value={
+                "study_name": "modified study name",
+                "study_description": "modified study description",
+                "status": 1,
+                "study_url": "http://modified.study.url/",
+                "img_url": "modifiedimg.jpg",
+            },
+            request_only=True,
+            response_only=False,
+        ),
+    ]
+)
 class StudySerializer(serializers.ModelSerializer):
     status_readable = serializers.ChoiceField(
         source="get_status_display", choices=Study.StatusType.choices, read_only=True

--- a/aid_web/studyapp/serializer.py
+++ b/aid_web/studyapp/serializer.py
@@ -17,8 +17,10 @@ class UserSerializer(serializers.ModelSerializer):
 
 
 class StudySerializer(serializers.ModelSerializer):
+    status_readable = serializers.CharField(source="get_status_display", read_only=True)
     leader = UserSerializer(many=False, read_only=True)
     users = UserSerializer(many=True, read_only=True)
+    # users_waiting = UserSerializer(many=True, read_only=True)
 
     class Meta:
         model = Study

--- a/aid_web/studyapp/serializer.py
+++ b/aid_web/studyapp/serializer.py
@@ -21,11 +21,12 @@ class UserSerializer(serializers.ModelSerializer):
 class StudyUserSerializer(serializers.Serializer):
     study_name = serializers.CharField(source="study.study_name")
     user_email = serializers.CharField(source="user.email")
+    user_id = serializers.IntegerField(source="user.id")
     is_approve = serializers.BooleanField()
 
     class Meta:
         model = StudyUserRelation
-        fields = ("study_name", "user_email", "is_approve")
+        fields = ("study_name", "user_email", "user_id", "is_approve")
 
 
 class StudySerializer(serializers.ModelSerializer):

--- a/aid_web/studyapp/urls.py
+++ b/aid_web/studyapp/urls.py
@@ -1,0 +1,11 @@
+from django.urls import include, path
+from rest_framework import routers
+
+from .views import StudyViewSet
+
+router = routers.DefaultRouter()
+router.register("study", StudyViewSet)
+
+urlpatterns = [
+    path("", include(router.urls)),
+]

--- a/aid_web/studyapp/views.py
+++ b/aid_web/studyapp/views.py
@@ -1,25 +1,32 @@
 # Create your views here.
+from django.db import transaction
 from rest_framework import viewsets
 from rest_framework.decorators import action
 from rest_framework.permissions import IsAuthenticatedOrReadOnly
 from rest_framework.response import Response
+from userapp.models import User
 
 from .models import Study
 from .permissions import IsOwnerOfStudyOrAdmin
-from .serializer import StudySerializer
+from .serializer import StudySerializer, StudyUserSerializer
 
 
+# TODO: queryset.get() 호출할 때 DoesNotExist 예외 처리
 class StudyViewSet(viewsets.ModelViewSet):
     queryset = Study.objects.all()
     serializer_class = StudySerializer
 
+    # 인증되지 않은 사용자는 읽기만(GET) 가능. 수정, 삭제 등은 study leader나 관리자만 가능.
     permission_classes = [IsAuthenticatedOrReadOnly, IsOwnerOfStudyOrAdmin]
 
+    # 스터디 생성. serializer의 create를 override해서 중간 테이블을 포함해 저장.
     # override
     def perform_create(self, serializer):
         serializer.save(leader=self.request.user)
 
+    # 스터디 나가기. 나가려는 사람이 leader라면 leader를 None으로 변경.
     @action(detail=True, methods=["patch"], permission_classes=[IsAuthenticatedOrReadOnly])
+    @transaction.atomic()
     def quit(self, request, pk):
         instance = self.get_object()
         instance.users.remove(request.user)
@@ -30,22 +37,85 @@ class StudyViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(instance)
         return Response(serializer.data)
 
+    # 스터디 참가. 스터디다 OPENED 상태여야 하고, 이미 참가한 사람은 참가 불가.
+    # 참가한 사용자는 참가 여부인 is_approve가 false.
     @action(detail=True, methods=["patch"], permission_classes=[IsAuthenticatedOrReadOnly])
     def join(self, request, pk):
         instance = self.get_object()
         if instance.status != Study.StatusType.OPENED:
-            return Response({"detail": "Study not available"}, status=406)
+            return Response({"detail": "Study not available"}, status=403)
         if instance.users.filter(id=request.user.id).exists():
             return Response({"detail": "User already joined study"}, status=403)
-        # if instance.users_waiting.filter(id=request.user.id).exists():
-        #     return Response({"detail": "User already exists in users_waiting"}, status=403)
-        # instance.users_waiting.add(request.user)
         instance.users.add(request.user)
         instance.save()
 
         serializer = self.get_serializer(instance)
         return Response(serializer.data)
 
-    # @action(detail=True, methods=["patch"], permission_classes=[IsOwnerOfStudyOrAdmin])
-    # def approval(self, request, pk):
-    #     self.get_object()
+    # 스터디 참가 승인을 위한 참가자 목록 확인. 스터디 leader나 관리자만 가능.
+    @action(
+        detail=True,
+        methods=["get"],
+        permission_classes=[IsOwnerOfStudyOrAdmin],
+    )
+    def approval(self, request, pk):
+        # https://stackoverflow.com/questions/69959797/has-object-permission-not-working-for-detail-action-decorator
+        study_obj = self.get_object()
+        user_relation = study_obj.studyuserrelation_set
+        serializer = StudyUserSerializer(user_relation, many=True)
+        return Response(serializer.data)
+
+    # 스터디 참가 승인. 스터디 leader나 관리자만 가능.
+    @action(
+        detail=True,
+        methods=["patch"],
+        permission_classes=[IsOwnerOfStudyOrAdmin],
+        url_path=r"approval/(?P<user_id>\d+)",
+    )
+    def approval_with_id(self, request, pk, user_id=None):
+        study_obj = self.get_object()
+        user_relation = study_obj.studyuserrelation_set.get(study_id=pk, user_id=user_id)
+        user_relation.is_approve = True
+        user_relation.save()
+        serializer = StudyUserSerializer(user_relation)
+        return Response(serializer.data)
+
+    # 참가자 삭제. 스터디 leader나 관리자만 가능.
+    @action(
+        detail=True,
+        methods=["patch"],
+        permission_classes=[IsOwnerOfStudyOrAdmin],
+        url_path=r"reject/(?P<user_id>\d+)",
+    )
+    def reject_with_id(self, request, pk, user_id=None):
+        instance = self.get_object()
+        if int(user_id) == instance.leader.id:
+            return Response({"detail": "Cannot reject leader"}, status=403)
+        instance.users.remove(user_id)
+        instance.save()
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)
+
+    # TODO
+    # 스터디 리더 변경을 아래와 같이 새로운 api endpoint로 둘 지,
+    # ModelViewSet이나 Serializer의 update를 override해서 구현할 지 고민.
+    @action(
+        detail=True,
+        methods=["patch"],
+        permission_classes=[IsOwnerOfStudyOrAdmin],
+        url_path=r"set-leader/(?P<user_id>\d+)",
+    )
+    def set_leader_with_id(self, request, pk, user_id):
+        instance = self.get_object()
+        user_queryset = instance.users.filter(id=user_id)
+        # TODO : exists와 get 둘 다 SQL 호출. 효율성 있게 추후 수정해보기.
+        # 참가중인 유저를 leader로 만들기.
+        if user_queryset.exists():
+            instance.leader = user_queryset.get()
+        else:  # 참가중이지 않은 유저를 leader로 만들기. users에도 추가.
+            user_obj = User.objects.get(id=user_id)
+            instance.leader = user_obj
+            instance.users.add(user_obj)
+        instance.save()
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)

--- a/aid_web/studyapp/views.py
+++ b/aid_web/studyapp/views.py
@@ -1,9 +1,11 @@
 # Create your views here.
 from rest_framework import viewsets
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
 
 from .models import Study
-from .permissions import IsOwnerOfStudyOrReadOnly
+from .permissions import IsOwnerOfStudyOrAdmin
 from .serializer import StudySerializer
 
 
@@ -11,10 +13,35 @@ class StudyViewSet(viewsets.ModelViewSet):
     queryset = Study.objects.all()
     serializer_class = StudySerializer
 
-    permission_classes = [IsAuthenticatedOrReadOnly, IsOwnerOfStudyOrReadOnly]
+    permission_classes = [IsAuthenticated, IsOwnerOfStudyOrAdmin]
 
     # override
     def perform_create(self, serializer):
         serializer.save(leader=self.request.user, users=[self.request.user])
 
-    # Q. ModelViewSet에 있는 update 사용 시 leader, users에 대한 정보를 넘기는 게 가능한가?
+    @action(detail=True, methods=["patch"], permission_classes=[IsAuthenticated])
+    def quit(self, request, pk):
+        instance = self.get_object()
+        instance.users.remove(request.user)
+        if instance.leader == request.user:
+            instance.leader = None
+        instance.save()
+
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)
+
+    @action(detail=True, methods=["patch"], permission_classes=[IsAuthenticated])
+    def join(self, request, pk):
+        instance = self.get_object()
+        if instance.status != Study.OPENED:
+            return Response({"detail": "Study not available"}, status=406)
+        if instance.users.filter(id=request.user.id).exists():
+            return Response({"detail": "User already joined study"}, status=403)
+        # if instance.users_waiting.filter(id=request.user.id).exists():
+        #     return Response({"detail": "User already exists in users_waiting"}, status=403)
+        # instance.users_waiting.add(request.user)
+        instance.users.add(request.user)
+        instance.save()
+
+        serializer = self.get_serializer(instance)
+        return Response(serializer.data)

--- a/aid_web/studyapp/views.py
+++ b/aid_web/studyapp/views.py
@@ -1,1 +1,20 @@
 # Create your views here.
+from rest_framework import viewsets
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+
+from .models import Study
+from .permissions import IsOwnerOfStudyOrReadOnly
+from .serializer import StudySerializer
+
+
+class StudyViewSet(viewsets.ModelViewSet):
+    queryset = Study.objects.all()
+    serializer_class = StudySerializer
+
+    permission_classes = [IsAuthenticatedOrReadOnly, IsOwnerOfStudyOrReadOnly]
+
+    # override
+    def perform_create(self, serializer):
+        serializer.save(leader=self.request.user, users=[self.request.user])
+
+    # Q. ModelViewSet에 있는 update 사용 시 leader, users에 대한 정보를 넘기는 게 가능한가?


### PR DESCRIPTION
## 설명
스터디 api 추가(스터디 CRUD, 나가기, 참가, 승인, 내보내기, 리더 변경)

## 변경 사항
* `config/base.py`에 studyapp 추가
* `config/base.py`에서 timezone을 한국으로 변경
* 스터디 model의 status field를 `IntegerChoice`로 변경
* 스터디 model의 users field가 customized된 중간 테이블을 사용하도록 변경
* 스터디 leader만 인증되는 권한(`IsOwnerOfStudyOrAdmin`) 추가

## 코드 리뷰시 참고사항
일부 주석 참고 바랍니다.

## 테스트 결과

<details>
  <summary>insomnia 수동 테스트 결과</summary>

  스터디 목록 출력 --- pass    
  스터디 목록 출력(no auth) --- pass  
  스터디 정보 출력 --- pass  
  스터디 생성 --- pass  
  스터디 생성(no auth) --- pass  
  스터디 삭제(no auth, wrong credential) --- pass  
  스터디 삭제(admin) --- pass  
  스터디 삭제(owner) --- pass  
  스터디 수정(no auth, wrong credential) --- pass  
  스터디 수정(owner) --- pass  
  스터디 수정(invalid value, field) --- pass  
  스터디 수정(admin) --- pass  
  스터디 참가(no auth, wrong credential) --- pass  
  스터디 참갸(not opened) --- pass  
  스터디 참가(already joined) --- pass  
  스터디 참가(non existing study) --- pass  
  스터디 승인 목록(non existing study) --- pass  
  스터디 승인 목록(no auth, wrong credential) --- pass  
  스터디 승인(no auth, wrong credential) --- pass  
  스터디 승인(admin) --- pass  
  스터디 나가기(no auth) --- pass  
  스터디 나가기(not joined) --- pass  
  스터디 나가기(joined) --- pass  
  스터디 나가기(leader)  
  스터디원 제거(no auth, wrong credential) --- pass  
  스터디원 제거 --- pass  
  스터디원 제거(reject leader) --- pass  
  스터디 리더 변경(no auth, wrong credential) --- pass  
  스터디 리더 변경(one of user) --- pass  
  스터디 리더 변경(not one of user) --- pass  
  스터디 리더 변경(can't change with same credential after leader change) --- pass   

</details>

수동 테스트 결과 토대로 테스트 코드 작성 예정

## 관련 이슈
#22 