### PR TITLE
test, production 환경용 docker compose

### DIFF
--- a/aid_web/config/settings/prod.py
+++ b/aid_web/config/settings/prod.py
@@ -1,9 +1,11 @@
 # flake8: noqa
 from .base import *  # noqa
 
+# TODO: production용 allowed host 설정
 # ALLOWED_HOSTS = []
 
 DEBUG = False
+SESSION_COOKIE_SECURE = True
 
 dotenv_path = BASE_DIR / ".prod.env"
 DATABASES = set_db(dotenv_path)

--- a/config/nginx.prod.conf
+++ b/config/nginx.prod.conf
@@ -1,0 +1,48 @@
+# TODO: https 연결
+user www-data;
+
+worker_processes auto; # nginx 프로세스 실행 가능 수 (실질적 웹서버) : 보통 auto 사용
+
+events { # 비동기 이벤트 방식 처리에 대한 옵션
+  worker_connections 1024; # 하나의 프로세스가 처리할 수 있는 연결 수
+  accept_mutex off;
+  use epoll;
+}
+# worker_proccesses x worker_connection = 최대 접속자 수
+
+http {
+
+    include mime.types;
+
+    # rewrite
+    # return(redirect)
+
+    upstream app_serve {
+        server DjangoApp:8000;
+    }
+
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log;
+    server {
+        listen 80;
+        server_name localhost;
+
+        # redirect
+
+        location / {
+            root /usr/share/front/build;
+            index index.html index.htm;
+            try_files $uri $uri/ /index.html =404;
+        }
+
+        location /api {
+            proxy_pass http://app_serve;
+            # 외부에서 헤더보고 자동으로 지정되는 값
+            proxy_set_header Host               $host;
+            proxy_set_header X-Real-IP          $remote_addr;
+            proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
+        }
+
+
+    }
+}

--- a/config/nginx.test.conf
+++ b/config/nginx.test.conf
@@ -1,0 +1,47 @@
+user www-data;
+
+worker_processes auto; # nginx 프로세스 실행 가능 수 (실질적 웹서버) : 보통 auto 사용
+
+events { # 비동기 이벤트 방식 처리에 대한 옵션
+  worker_connections 1024; # 하나의 프로세스가 처리할 수 있는 연결 수
+  accept_mutex off;
+  use epoll;
+}
+# worker_proccesses x worker_connection = 최대 접속자 수
+
+http {
+
+    include mime.types;
+
+    # rewrite
+    # return(redirect)
+
+    upstream app_serve {
+        server DjangoApp:8000;
+    }
+
+    access_log /var/log/nginx/access.log;
+    error_log /var/log/nginx/error.log;
+    server {
+        listen 80;
+        server_name localhost;
+
+        # redirect
+
+        location / {
+            root /usr/share/front/build;
+            index index.html index.htm;
+            try_files $uri $uri/ /index.html =404;
+        }
+
+        location /api {
+            proxy_pass http://app_serve;
+            # 외부에서 헤더보고 자동으로 지정되는 값
+            proxy_set_header Host               $host;
+            proxy_set_header X-Real-IP          $remote_addr;
+            proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
+        }
+
+
+    }
+}

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -4,19 +4,6 @@
 version: '3.8'
 
 services:
-  web-server:
-    container_name: nginx
-    image: nginx:latest
-    restart: always
-    environment:
-      TZ: "Asia/Seoul"
-    volumes:
-      - ./config/nginx.test.conf:/etc/nginx/nginx.conf
-    ports:
-      - 80:80
-    networks:
-      - aid
-
   server:
     container_name: DjangoApp
     depends_on:
@@ -32,7 +19,7 @@ services:
       - 8000:8000
     environment:
       TZ: "Asia/Seoul"
-      DJANGO_SETTINGS_MODULE: config.settings.test
+      DJANGO_SETTINGS_MODULE: config.settings.prod
     networks:
       - aid
 

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,9 +1,23 @@
 # https://velog.io/@rlagurwns112/docker-compose%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-django-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-%EB%B0%B0%ED%8F%AC
 # https://afsdzvcx123.tistory.com/entry/Docker-PostgreSQL-Docker-Compose-%ED%8C%8C%EC%9D%BC-%EC%9E%91%EC%84%B1
+# https://meongj-devlog.tistory.com/145 (gunicorn)
 
 version: '3.8'
 
 services:
+  web-server:
+    container_name: nginx
+    image: nginx:latest
+    restart: always
+    environment:
+      TZ: "Asia/Seoul"
+    volumes:
+      - ./config/nginx.test.conf:/etc/nginx/nginx.conf
+    ports:
+      - 80:80 # TODO: https 연결
+    networks:
+      - aid
+
   server:
     container_name: DjangoApp
     depends_on:
@@ -14,7 +28,7 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./aid_web:/aid_web
-    command: sh -c "cd /aid_web && python manage.py makemigrations && python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
+    command: sh -c "cd /aid_web && python manage.py makemigrations && python manage.py migrate && gunicorn config.wsgi:application --bind 0.0.0.0:8000 --timeout 90"
     ports:
       - 8000:8000
     environment:

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -27,7 +27,7 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./aid_web:/aid_web
-    command: sh -c "cd /aid_web && python manage.py makemigrations && python manage.py migrate && gunicorn config.wsgi:application --bind 0.0.0.0:8000 --timeout 90"
+    command: sh -c "cd /aid_web && python manage.py makemigrations && python manage.py migrate && gunicorn config.wsgi:application --bind 0.0.0.0:8000 --timeout 90 --reload"
     ports:
       - 8000:8000
     environment:

--- a/docker-compose.test.yaml
+++ b/docker-compose.test.yaml
@@ -27,7 +27,7 @@ services:
       dockerfile: Dockerfile
     volumes:
       - ./aid_web:/aid_web
-    command: sh -c "cd /aid_web && python manage.py makemigrations && python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
+    command: sh -c "cd /aid_web && python manage.py makemigrations && python manage.py migrate && gunicorn config.wsgi:application --bind 0.0.0.0:8000 --timeout 90"
     ports:
       - 8000:8000
     environment:

--- a/docs/docker_explain.md
+++ b/docs/docker_explain.md
@@ -7,7 +7,7 @@ Test 환경 : PostgreSQL database 서버 및 Django 모두 docker로 실행
 
 ## docker관련 파일 구성요소
 **docker-compose.yaml**
-- docker compose를 사용해, nginx 서버(미구현), Django, PostgreSQL 서버 각각의 container를 deploy할 수 있도록 해주는 파일
+- docker compose를 사용해, nginx 서버, Django, PostgreSQL 서버 각각의 container를 deploy할 수 있도록 해주는 파일
 - docker container는 `aid` 이름의 network 사용
 - `server` : Django server
   - test, production 환경에서만 deploy.
@@ -20,12 +20,16 @@ Test 환경 : PostgreSQL database 서버 및 Django 모두 docker로 실행
   - database 파일은 `/var/lib/postgresql/data` mount
   - PostgreSQL container는 5432 port를 통해 접속 가능하도록 설정
   - 환경 변수 파일은 `./env/.db.env`사용
+- `nginx`
+  - test, production 환경에서만 사용(이후 https 연결 및 load balancing 등의 기능을 위해)
+  - `./config/nginx.test.conf` 및 `nginx.prod.conf`의 nginx conf 파일을 사용
 - PostgreSQL environment variable(env에서 확인)
   - `POSTGRES_USER` : PostgreSQL에 접속할 사용자(지정하지 않으면 `postgres`사용.)
   - `POSTGRES_PASSWORD` : PostgreSQL 비밀번호
   - `POSTGRES_DB` : 생성할 데이터베이스 이름
   - `TZ` : timezone. `TZ=Asia/Seoul`로 지정.
-
+- test, production환경에서는 django의 `runserver` 대신, `gunicorn` 사용
+  - django 공식문서에서도 배포 환경에서 runserver 사용을 권장하지 않고, gunicorn을 사용하면 요청 분산이 가능해짐.
 
 ### Dockerfile
 Django용 이미지 생성을 위한 Dockerfile. poetry 설치 후, pyproject.toml 내의 패키지 설치

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,8 @@ python-dotenv = "^1.0.0"
 psycopg2-binary = "^2.9.9"
 django-seed = "^0.3.1"
 drf-spectacular = "^0.27.0"
+gunicorn = "^21.2.0"
+uvicorn = {extras = ["standard"], version = "^0.27.0.post1"}
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
## 설명
test및 production을 위한 docker-compose 파일 생성

## 변경 사항
* `docker-compose.test.yaml`, `docker-compose.prod.yaml` 생성
* 이후 https 연결을 위한 nginx 포함
* django runserver대신 gunicorn 사용

## 코드 리뷰시 참고사항
https://leffept.tistory.com/282 (gunicorn 사용 이유 및 설정방법)

## 테스트 결과
GCP compute engine에서 배포 및 접속 확인됨.

## 관련 이슈
