### PR TITLE
News get api

### DIFF
--- a/aid_web/config/settings/base.py
+++ b/aid_web/config/settings/base.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
     "seeding",  # 더미 데이터 생성용(폴더 이름)
     "drf_spectacular",
     "corsheaders",
+    "storages",
 ]
 
 MIDDLEWARE = [
@@ -206,3 +207,4 @@ CORS_ALLOWED_ORIGINS = [
 # }
 
 MEDIA_ROOT = os.path.join(BASE_DIR, "media")
+STATIC_ROOT = os.path.join(BASE_DIR, "static")

--- a/aid_web/config/settings/base.py
+++ b/aid_web/config/settings/base.py
@@ -37,6 +37,7 @@ ALLOWED_HOSTS = []
 INSTALLED_APPS = [
     "userapp.apps.UserappConfig",
     "studyapp.apps.StudyappConfig",
+    "newsapp.apps.NewsappConfig",
     # "projectapp.apps.ProjectappConfig",
     "django.contrib.admin",
     "django.contrib.auth",
@@ -51,7 +52,7 @@ INSTALLED_APPS = [
 ]
 
 MIDDLEWARE = [
-    "corsheaders.middleward.CorsMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
@@ -139,6 +140,7 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
 STATIC_URL = "static/"
+MEDIA_URL = "media/"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
@@ -201,3 +203,5 @@ CORS_ALLOWED_ORIGINS = [
 #     "SLIDING_TOKEN_LIFETIME": timedelta(minutes=5),
 #     "SLIDING_TOKEN_REFRESH_LIFETIME": timedelta(days=1),
 # }
+
+MEDIA_ROOT = os.path.join(BASE_DIR, "media")

--- a/aid_web/config/settings/prod.py
+++ b/aid_web/config/settings/prod.py
@@ -3,9 +3,9 @@ from .base import *  # noqa
 
 # TODO: production용 allowed host 설정
 # TODO: user uploaded media file. https://docs.djangoproject.com/en/4.1/topics/security/#user-uploaded-content
-ALLOWED_HOSTS = ["*"]
+ALLOWED_HOSTS = []
 
-DEBUG = True
+DEBUG = False
 SESSION_COOKIE_SECURE = True
 
 dotenv_path = BASE_DIR / ".prod.env"

--- a/aid_web/config/settings/prod.py
+++ b/aid_web/config/settings/prod.py
@@ -2,10 +2,27 @@
 from .base import *  # noqa
 
 # TODO: production용 allowed host 설정
-# ALLOWED_HOSTS = []
+# TODO: user uploaded media file. https://docs.djangoproject.com/en/4.1/topics/security/#user-uploaded-content
+ALLOWED_HOSTS = ["*"]
 
-DEBUG = False
+DEBUG = True
 SESSION_COOKIE_SECURE = True
 
 dotenv_path = BASE_DIR / ".prod.env"
 DATABASES = set_db(dotenv_path)
+
+# https://testdriven.io/blog/storing-django-static-and-media-files-on-amazon-s3/#s3-bucket
+AWS_ACCESS_KEY_ID = os.environ["AWS_ACCESS_KEY_ID"]
+AWS_SECRET_ACCESS_KEY = os.environ["AWS_SECRET_ACCESS_KEY"]
+AWS_STORAGE_BUCKET_NAME = os.environ["AWS_STORAGE_BUCKET_NAME"]
+AWS_DEFAULT_ACL = None
+AWS_S3_CUSTOM_DOMAIN = f"{AWS_STORAGE_BUCKET_NAME}.s3.amazonaws.com"
+AWS_S3_OBJECT_PARAMETERS = {"CacheControl": "max-age=86400"}
+# s3 static settings
+STATIC_LOCATION = "static"
+STATIC_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/{STATIC_LOCATION}/"
+STATICFILES_STORAGE = "config.storage_backends.StaticStorage"
+# s3 public media settings
+PUBLIC_MEDIA_LOCATION = "media"
+MEDIA_URL = f"https://{AWS_S3_CUSTOM_DOMAIN}/{PUBLIC_MEDIA_LOCATION}/"
+DEFAULT_FILE_STORAGE = "config.storage_backends.PublicMediaStorage"

--- a/aid_web/config/storage_backends.py
+++ b/aid_web/config/storage_backends.py
@@ -1,0 +1,12 @@
+from storages.backends.s3boto3 import S3Boto3Storage
+
+
+class StaticStorage(S3Boto3Storage):
+    location = "static"
+    default_acl = "public-read"
+
+
+class PublicMediaStorage(S3Boto3Storage):
+    location = "media"
+    default_acl = "public-read"
+    file_overwrite = False

--- a/aid_web/config/urls.py
+++ b/aid_web/config/urls.py
@@ -24,7 +24,10 @@ urlpatterns = [
     path("admin/", admin.site.urls),
     path("api/", include("studyapp.urls")),
     path("api/", include("userapp.urls")),
+    path("api/", include("newsapp.urls")),
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     path("api/schema/swagger-ui/", SpectacularSwaggerView.as_view(url_name="schema"), name="swagger-ui"),
     path("api/schema/redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
 ]
+
+# urlpatterns += static(MEDIA_URL, document_root=MEDIA_ROOT)

--- a/aid_web/config/urls.py
+++ b/aid_web/config/urls.py
@@ -14,9 +14,12 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
+
+from .settings.base import MEDIA_ROOT, MEDIA_URL
 
 # from testapp.views import hello_rest_api
 
@@ -30,4 +33,4 @@ urlpatterns = [
     path("api/schema/redoc/", SpectacularRedocView.as_view(url_name="schema"), name="redoc"),
 ]
 
-# urlpatterns += static(MEDIA_URL, document_root=MEDIA_ROOT)
+urlpatterns += static(MEDIA_URL, document_root=MEDIA_ROOT)

--- a/aid_web/newsapp/admin.py
+++ b/aid_web/newsapp/admin.py
@@ -1,0 +1,1 @@
+# Register your models here.

--- a/aid_web/newsapp/apps.py
+++ b/aid_web/newsapp/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class NewsappConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "newsapp"

--- a/aid_web/newsapp/models.py
+++ b/aid_web/newsapp/models.py
@@ -1,0 +1,11 @@
+from django.db import models
+
+
+class News(models.Model):
+    image = models.ImageField(upload_to="news_image/", default=None)
+    title = models.CharField(max_length=50)
+    content = models.TextField()
+    created_at = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return self.title

--- a/aid_web/newsapp/serializer.py
+++ b/aid_web/newsapp/serializer.py
@@ -1,0 +1,9 @@
+from rest_framework import serializers
+
+from .models import News
+
+
+class NewsSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = News
+        fields = ("id", "image", "title", "content", "created_at")

--- a/aid_web/newsapp/tests.py
+++ b/aid_web/newsapp/tests.py
@@ -1,0 +1,1 @@
+# Create your tests here.

--- a/aid_web/newsapp/urls.py
+++ b/aid_web/newsapp/urls.py
@@ -1,0 +1,8 @@
+from rest_framework import routers
+
+from .views import NewsViewSet
+
+router = routers.DefaultRouter()
+router.register("news", NewsViewSet, basename="news")
+
+urlpatterns = router.urls

--- a/aid_web/newsapp/views.py
+++ b/aid_web/newsapp/views.py
@@ -1,0 +1,21 @@
+from rest_framework import mixins, viewsets
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
+
+from .models import News
+from .serializer import NewsSerializer
+
+
+# 현재는 뉴스 조회만 가능, 생성은 test용으로 로그인하면 생성할 수 있도록 해놓음.
+# 이후 CRUD가 모두 필요할 때 mixin 대신 ModelViewSet을 상속하는 것으로 변경.
+class NewsViewSet(
+    mixins.CreateModelMixin,
+    mixins.RetrieveModelMixin,
+    # mixins.UpdateModelMixin,
+    # mixins.DestroyModelMixin,
+    mixins.ListModelMixin,
+    viewsets.GenericViewSet,
+):
+    queryset = News.objects.all()
+    serializer_class = NewsSerializer
+
+    permission_classes = [IsAuthenticatedOrReadOnly]

--- a/aid_web/newsapp/views.py
+++ b/aid_web/newsapp/views.py
@@ -1,5 +1,5 @@
 from rest_framework import mixins, viewsets
-from rest_framework.permissions import IsAuthenticatedOrReadOnly
+from rest_framework.permissions import AllowAny
 
 from .models import News
 from .serializer import NewsSerializer
@@ -18,4 +18,4 @@ class NewsViewSet(
     queryset = News.objects.all()
     serializer_class = NewsSerializer
 
-    permission_classes = [IsAuthenticatedOrReadOnly]
+    permission_classes = [AllowAny]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ django-seed = "^0.3.1"
 drf-spectacular = "^0.27.0"
 djangorestframework-simplejwt = "^5.3.1"
 django-cors-headers = "^4.3.1"
+pillow = "^10.2.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ uvicorn = {extras = ["standard"], version = "^0.27.0.post1"}
 djangorestframework-simplejwt = "^5.3.1"
 django-cors-headers = "^4.3.1"
 pillow = "^10.2.0"
-
+django-storages = "^1.14.2"
+boto3 = "^1.34.39"
 
 [tool.poetry.group.dev.dependencies]
 pre-commit = "^3.5.0"


### PR DESCRIPTION
## 설명
News 관련 api 제작

## 변경 사항
* newsapp 생성(model, serializer, view 생성)
* production 용 media file을 s3와 연결

## 코드 리뷰시 참고사항
* 요청받은 사항은 get만 사용가능하도록 되어있지만, 개발 편의를 위해 post까지 사용가능하도록 해놨습니다(이후 필요 시 mixin 제거하여 get만 사용가능하도록 변경)

## 테스트 결과

## 관련 이슈
closes: #43 