### PR TITLE
Certbot HTTPS 추가, local용 docker compose 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -347,3 +347,6 @@ $RECYCLE.BIN/
 
 # Django, docker private settings
 *.env
+
+# certbot related files
+certbot/

--- a/aid_web/config/settings/base.py
+++ b/aid_web/config/settings/base.py
@@ -50,7 +50,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "rest_framework",  # Django RestFrameWork 사용"
-    "seeding",  # 더미 데이터 생성용(폴더 이름)
+    # "seeding",  # 더미 데이터 생성용(폴더 이름)
     "drf_spectacular",
     "corsheaders",
     "storages",

--- a/aid_web/config/settings/prod.py
+++ b/aid_web/config/settings/prod.py
@@ -3,7 +3,7 @@ from .base import *  # noqa
 
 # TODO: production용 allowed host 설정
 # TODO: user uploaded media file. https://docs.djangoproject.com/en/4.1/topics/security/#user-uploaded-content
-ALLOWED_HOSTS = ["backend.pnuaid.com"]
+ALLOWED_HOSTS = ["pnuaid.com"]
 
 CSRF_TRUSTED_ORIGINS = ["https://*.pnuaid.com/", "https://*.pnuaid.com/admin", "https://*.127.0.0.1"]
 

--- a/config/nginx.prod.conf
+++ b/config/nginx.prod.conf
@@ -26,9 +26,31 @@ http {
     error_log /var/log/nginx/error.log;
     server {
         listen 80;
-        server_name localhost;
+        # server_name localhost;
 
+        server_name pnuaid.com;
         # redirect
+
+        location / {
+            return 301 https://$host$request_uri;
+        }
+
+        location ~ /.well-known/acme-challenge {
+            allow all;
+            root /var/www/certbot;
+        }
+
+    }
+
+    server {
+        listen 443 ssl;
+        server_name pnuaid.com;
+        server_tokens off;
+
+        ssl_certificate /etc/letsencrypt/live/pnuaid.com/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/pnuaid.com/privkey.pem;
+
+        ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
 
         location /admin {
             proxy_pass http://app_serve;
@@ -45,7 +67,5 @@ http {
             proxy_set_header X-Real-IP          $remote_addr;
             proxy_set_header X-Forwarded-For    $proxy_add_x_forwarded_for;
         }
-
-
     }
 }

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -1,6 +1,7 @@
 # https://velog.io/@rlagurwns112/docker-compose%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-django-%ED%94%84%EB%A1%9C%EC%A0%9D%ED%8A%B8-%EB%B0%B0%ED%8F%AC
 # https://afsdzvcx123.tistory.com/entry/Docker-PostgreSQL-Docker-Compose-%ED%8C%8C%EC%9D%BC-%EC%9E%91%EC%84%B1
 # https://meongj-devlog.tistory.com/145 (gunicorn)
+# https://node-js.tistory.com/32, https://pentacent.medium.com/nginx-and-lets-encrypt-with-docker-in-less-than-5-minutes-b4b8a60d3a71 (https)
 
 version: '3.8'
 
@@ -13,10 +14,23 @@ services:
       TZ: "Asia/Seoul"
     volumes:
       - ./config/nginx.prod.conf:/etc/nginx/nginx.conf
+      - ./certbot/conf:/etc/letsencrypt
+      - ./certbot/www:/var/www/certbot
     ports:
-      - 80:80 # TODO: https 연결
+      - 80:80
+      - 443:443
     networks:
       - aid
+    command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
+
+  certbot:
+    image: certbot/certbot:latest
+    command: certonly --webroot --webroot-path=/var/www/certbot --email ${CERT_EMAIL} --agree-tos --no-eff-email -d pnuaid.com
+    volumes:
+      - ./certbot/conf:/etc/letsencrypt
+      - ./certbot/logs:/var/log/letsencrypt
+      - ./certbot/www:/var/www/certbot
+    entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
 
   server:
     container_name: DjangoApp

--- a/docs/docker_explain.md
+++ b/docs/docker_explain.md
@@ -23,6 +23,9 @@ Test 환경 : PostgreSQL database 서버 및 Django 모두 docker로 실행
 - `nginx`
   - test, production 환경에서만 사용(이후 https 연결 및 load balancing 등의 기능을 위해)
   - `./config/nginx.test.conf` 및 `nginx.prod.conf`의 nginx conf 파일을 사용
+- `certbot`
+  - 무료 https 인증서 발급용(이후 변경 가능)
+  - entrypoint를 이용, 갱신 필요시 인증서 재발급
 - PostgreSQL environment variable(env에서 확인)
   - `POSTGRES_USER` : PostgreSQL에 접속할 사용자(지정하지 않으면 `postgres`사용.)
   - `POSTGRES_PASSWORD` : PostgreSQL 비밀번호


### PR DESCRIPTION
## 설명
* aws 비용 감소를 위한 certbot https추가
* frontend 개발 시 편의성을 위한 local docker compose 파일 수정

## 변경 사항
* nginx 설정 및 production용 docker-compose에 certbot https 추가
* local용 docker-compose에 django 추가
* 도메인 backend.pnuaid.com -> pnuaid.com으로 변경

## 코드 리뷰시 참고사항

## 테스트 결과

## 관련 이슈
